### PR TITLE
Revised $changed assignment to remove E_NOTICE error

### DIFF
--- a/simpleCachedCurl.inc.php
+++ b/simpleCachedCurl.inc.php
@@ -30,9 +30,7 @@ function simpleCachedCurl($url,$expires,$debug=false){
     }
     $hash = md5($url);
     $filename = dirname(__FILE__).'/cache/' . $hash . '.cache';
-    if(file_exists($filename)) {
-      $changed = filemtime($filename);
-    }
+    $changed = file_exists($filename) ? filemtime($filename) : 0;
     $now = time();
     $diff = $now - $changed;   
     if ( !$changed || ($diff > $expires) ) {


### PR DESCRIPTION
Changed $changed assignment to return 0 if there's no cache file, this eliminated an E_NOTICE error that comes up when evaluating $changed when it doesn't exists
